### PR TITLE
Updated Confluent.Kafka to 1.5.2

### DIFF
--- a/Obvs.Kafka.Tests/Obvs.Kafka.Tests.csproj
+++ b/Obvs.Kafka.Tests/Obvs.Kafka.Tests.csproj
@@ -3,11 +3,11 @@
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.3.0" />
-    <PackageReference Include="FakeItEasy" Version="6.0.0" />
-    <PackageReference Include="NLog" Version="4.6.8" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.2" />
+    <PackageReference Include="FakeItEasy" Version="6.2.1" />
+    <PackageReference Include="NLog" Version="4.7.5" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="Obvs.Serialization.Json" Version="5.0.1.32" />
+    <PackageReference Include="Obvs.Serialization.Json" Version="5.0.2.33" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Obvs.Kafka\Obvs.Kafka.csproj" />

--- a/Obvs.Kafka.sln
+++ b/Obvs.Kafka.sln
@@ -7,7 +7,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Obvs.Kafka", "Obvs.Kafka\Ob
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Obvs.Kafka.Tests", "Obvs.Kafka.Tests\Obvs.Kafka.Tests.csproj", "{448C0387-1D3B-44DE-A27C-32BC3BD93C70}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{4C889491-65F4-48D7-AE2E-0F1C47C4EE3E}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".build", ".build", "{4C889491-65F4-48D7-AE2E-0F1C47C4EE3E}"
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
 	EndProjectSection

--- a/Obvs.Kafka/Obvs.Kafka.csproj
+++ b/Obvs.Kafka/Obvs.Kafka.csproj
@@ -7,12 +7,12 @@
     <Authors>Christopher Read</Authors>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageProjectUrl>http://christopherread.github.io/Obvs</PackageProjectUrl>
-    <PackageReleaseNotes>Updated to .NET Standard 2.0 and Obvs 5.0</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated Confluent.Kafka to 1.5.2</PackageReleaseNotes>
     <Description>Kafka transport support for Obvs</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.3.0" />
-    <PackageReference Include="Obvs" Version="5.0.1.42" />
-    <PackageReference Include="protobuf-net" Version="2.4.4" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.2" />
+    <PackageReference Include="Obvs" Version="5.0.2.52" />
+    <PackageReference Include="protobuf-net" Version="2.4.6" />
   </ItemGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.0.0.{build}
+version: 5.0.2.{build}
 skip_tags: true
 image: Visual Studio 2019
 configuration: Release
@@ -24,3 +24,9 @@ build:
   publish_nuget: true
   publish_nuget_symbols: true
   verbosity: minimal
+deploy:
+  provider: NuGet
+  api_key:
+    secure: /JaqWVLPjPNAxdRPnQPxqePn+MwzY/Yd2ftPlza0l9GNC16H30puAH/sNZ1De8x3
+  skip_symbols: false
+  artifact: /.*(?<!symbols)(\.|\.s)nupkg/


### PR DESCRIPTION
Just updating package versions across the board...

...before the bigger 6.0 changes, which are:

- Move all Obvs repositories into one mono-repo
- Upgrade everything to .NET 5.0
- Upgrade to Rx 5.0
- Maybe improve fluent config interfaces so everything isn't all on the same level/hierarchy
- Maybe move to Azure DevOps if there's any benefit